### PR TITLE
support well-known env-vars for setting username and password

### DIFF
--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -13,6 +13,8 @@ module Zanzibar
     def initialize(args = {})
       if args[:username]
         @@username = args[:username]
+      elsif ENV['ZANZIBAR_USER']
+        @@username = ENV['ZANZIBAR_USER']
       else
         @@username = ENV['USER']
       end
@@ -22,11 +24,15 @@ module Zanzibar
       else
         @@wsdl = get_wsdl_location
       end
+
       if args[:pwd]
         @@password = args[:pwd]
+      elsif ENV['ZANZIBAR_PASSWORD']
+        @@password = ENV['ZANZIBAR_PASSWORD']
       else
         @@password = prompt_for_password
       end
+
       if args[:domain]
         @@domain = args[:domain]
       else
@@ -34,6 +40,14 @@ module Zanzibar
       end
       args[:globals] = {} unless args[:globals]
       init_client(args[:globals])
+    end
+
+    def get_client_username
+      @@username
+    end
+
+    def get_client_password
+      @@password
     end
 
     ## Initializes the Savon client class variable with the wdsl document location and optional global variables

--- a/spec/zanzibar_spec.rb
+++ b/spec/zanzibar_spec.rb
@@ -110,4 +110,14 @@ describe 'Zanzibar Test' do
     expect(File.read('attachment.txt')).to eq("I am a secret attachment\n")
     File.delete('attachment.txt')
   end
+
+  it 'should use environment variables for credentials' do
+    ENV['ZANZIBAR_USER'] = "environment_user"
+    ENV['ZANZIBAR_PASSWORD'] = "environment_password"
+    client = Zanzibar::Zanzibar.new(domain: 'zanzitest.net', wsdl: 'spec/scrt.wsdl')
+    expect(client.get_client_username).to eq(ENV['ZANZIBAR_USER'])
+    expect(client.get_client_password).to eq(ENV['ZANZIBAR_PASSWORD'])
+    ENV.delete 'ZANZIBAR_PASSWORD'
+    ENV.delete 'ZANZIBAR_USER'
+  end
 end


### PR DESCRIPTION
Support well-known environment variable names when looking for credentials.

Favor credentials directly passed to constructor. If not present, try these environment variables. If not present, prompt for input.

This will enable us to easily access secrets from Jenkins jobs used masked passwords.
