### PR TITLE
Savepasswords

### DIFF
--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -110,7 +110,7 @@ module Zanzibar
       raise "There was an error getting the secret with id #{scrt_id}: #{err}"
     end
 
-    ## Retrieve a simple password from a secret
+    ## Retrieve a simple password from a secret, and save it to a file if requested
     # Will raise an error if there are any issues
     # @param [Integer] the secret id
     # @return [String] the password for the given secret
@@ -123,9 +123,23 @@ module Zanzibar
       raise "There was an error getting the password for secret #{scrt_id}: #{err}"
     end
 
+    ## Get the password, save it to a file, and return the path to the file.
+    def get_password_and_save(scrt_id, path, name)
+      password = get_password(scrt_id)
+      save_password_to_file(password, path, name)
+      return File.join(path, name)
+    end
+
     def write_secret_to_file(path, secret_response)
       File.open(File.join(path, secret_response[:file_name]), 'wb') do |file|
         file.puts Base64.decode64(secret_response[:file_attachment])
+      end
+    end
+
+    ## Write the password to a file. Intended for use with a Zanzifile
+    def save_password_to_file(password, path, name)
+      File.open(File.join(path, name), 'wb') do |file|
+        file.puts password
       end
     end
 

--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -139,7 +139,7 @@ module Zanzibar
     ## Write the password to a file. Intended for use with a Zanzifile
     def save_password_to_file(password, path, name)
       File.open(File.join(path, name), 'wb') do |file|
-        file.print Base64.strict_encode64(password)
+        file.print password
       end
     end
 

--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -110,7 +110,7 @@ module Zanzibar
       raise "There was an error getting the secret with id #{scrt_id}: #{err}"
     end
 
-    ## Retrieve a simple password from a secret, and save it to a file if requested
+    ## Retrieve a simple password from a secret
     # Will raise an error if there are any issues
     # @param [Integer] the secret id
     # @return [String] the password for the given secret

--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -2,6 +2,7 @@ require 'zanzibar/version'
 require 'savon'
 require 'io/console'
 require 'fileutils'
+require 'yaml'
 
 module Zanzibar
   ##
@@ -124,9 +125,11 @@ module Zanzibar
     end
 
     ## Get the password, save it to a file, and return the path to the file.
-    def get_password_and_save(scrt_id, path, name)
-      password = get_password(scrt_id)
-      save_password_to_file(password, path, name)
+    def get_username_and_password_and_save(scrt_id, path, name)
+      secret_items = get_secret(scrt_id)[:secret][:items][:secret_item]
+      password = get_secret_item_by_field_name(secret_items, 'Password')[:value]
+      username = get_secret_item_by_field_name(secret_items, 'Username')[:value]
+      save_username_and_password_to_file(password, username, path, name)
       return File.join(path, name)
     end
 
@@ -137,9 +140,10 @@ module Zanzibar
     end
 
     ## Write the password to a file. Intended for use with a Zanzifile
-    def save_password_to_file(password, path, name)
+    def save_username_and_password_to_file(password, username, path, name)
+      user_pass = {'username' => username.to_s, 'password' => password.to_s}.to_yaml
       File.open(File.join(path, name), 'wb') do |file|
-        file.print password
+        file.print user_pass
       end
     end
 

--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -139,7 +139,7 @@ module Zanzibar
     ## Write the password to a file. Intended for use with a Zanzifile
     def save_password_to_file(password, path, name)
       File.open(File.join(path, name), 'wb') do |file|
-        file.puts password
+        file.print Base64.strict_encode64(password)
       end
     end
 

--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -44,7 +44,7 @@ module Zanzibar
       end
 
       def ensure_secrets_path
-        FileUtils.mkdir_p(@settings['secret_dir'])
+        FileUtils.mkdir_p(@settings['secret_dir']) unless @settings['secret_dir'] == nil
       end
 
       def resolved_file?
@@ -85,14 +85,13 @@ module Zanzibar
 
         downloaded_secrets = {}
         remote_secrets.each do |key, secret|
-          puts "Downloading #{key} - #{secret['id']}"
           downloaded_secrets[key] = download_one_secret(secret['id'],
                                                         secret['label'],
                                                         @settings['secret_dir'],
                                                         args,
                                                         secret['name'] || "#{secret['id']}_password")
 
-          debug { "Downloaded secret: #{key} to #{secret['path']}..." }
+          debug { "Downloaded secret: #{key} to #{@settings['secret_dir']}..." }
         end
 
         downloaded_secrets

--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -99,7 +99,7 @@ module Zanzibar
 
       def download_one_secret(scrt_id, label, path, args, name = nil)
         if label == 'Password'
-          path = zanzibar(args).get_password_and_save(scrt_id, path, name)
+          path = zanzibar(args).get_username_and_password_and_save(scrt_id, path, name)
           { path: path, hash: Digest::MD5.file(path).hexdigest }
         else
           path = zanzibar(args).download_secret_file(scrt_id: scrt_id,

--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -20,6 +20,7 @@ module Zanzibar
       def run
         ensure_zanzifile
         load_required_secrets
+        ensure_secrets_path
         validate_environment
         load_resolved_secrets if resolved_file?
         validate_local_secrets unless @update
@@ -40,6 +41,10 @@ module Zanzibar
       def ensure_zanzifile
         fail Error, NO_ZANZIFILE_ERROR unless File.exist? ZANZIFILE_NAME
         debug { "#{ZANZIFILE_NAME} located..." }
+      end
+
+      def ensure_secrets_path
+        FileUtils.mkdir_p(@settings['secret_dir'])
       end
 
       def resolved_file?
@@ -80,23 +85,29 @@ module Zanzibar
 
         downloaded_secrets = {}
         remote_secrets.each do |key, secret|
+          puts "Downloading #{key} - #{secret['id']}"
           downloaded_secrets[key] = download_one_secret(secret['id'],
                                                         secret['label'],
                                                         @settings['secret_dir'],
-                                                        args)
+                                                        args,
+                                                        secret['name'] || "#{secret['id']}_password")
 
-          debug { "Downloaded secret: #{key} to #{path}..." }
+          debug { "Downloaded secret: #{key} to #{secret['path']}..." }
         end
 
         downloaded_secrets
       end
 
-      def download_one_secret(scrt_id, label, path, args)
-        path = zanzibar(args).download_secret_file(scrt_id: scrt_id,
+      def download_one_secret(scrt_id, label, path, args, name = nil)
+        if label == 'Password'
+          path = zanzibar(args).get_password_and_save(scrt_id, path, name)
+          { path: path, hash: Digest::MD5.file(path).hexdigest }
+        else
+          path = zanzibar(args).download_secret_file(scrt_id: scrt_id,
                                                    type: label,
                                                    path: path)
-
-        { path: path, hash: Digest::MD5.file(path).hexdigest }
+          { path: path, hash: Digest::MD5.file(path).hexdigest }
+        end
       end
 
       def update_resolved_file(new_secrets)

--- a/lib/zanzibar/cli.rb
+++ b/lib/zanzibar/cli.rb
@@ -53,6 +53,7 @@ module Zanzibar
     end
 
     desc 'plunder', "Alias to `#{APPLICATION_NAME} bundle`", :hide => true
+    option 'verbose', type: :boolean, default: false, aliases: :v
     alias_method :plunder, :bundle
 
     desc 'install', "Alias to `#{APPLICATION_NAME} bundle`"

--- a/lib/zanzibar/version.rb
+++ b/lib/zanzibar/version.rb
@@ -1,4 +1,4 @@
 # The version of the gem
 module Zanzibar
-  VERSION = '0.1.16'
+  VERSION = '0.1.17'
 end

--- a/spec/lib/zanzibar_spec.rb
+++ b/spec/lib/zanzibar_spec.rb
@@ -104,15 +104,15 @@ describe 'Zanzibar Test' do
     File.delete('attachment.txt')
   end
 
-  it 'should save a password to a file' do
+  it 'should save credentials to a file' do
     stub_request(:any, 'https://www.zanzitest.net/webservices/sswebservice.asmx')
       .to_return(body: AUTH_XML, status: 200).then
       .to_return(body: SECRET_XML, status: 200)
 
-      client.get_password_and_save(1234, '.', 'zanziTestPassword')
-      expect(File.exist? 'zanziTestPassword')
-      expect(File.read('zanziTestPassword')).to eq('zanziUserPassword')
-      File.delete('zanziTestPassword')
+      client.get_username_and_password_and_save(1234, '.', 'zanziTestCreds')
+      expect(File.exist? 'zanziTestCreds')
+      expect(File.read('zanziTestCreds')).to eq({'username' => 'ZanziUser', 'password' => 'zanziUserPassword'}.to_yaml)
+      File.delete('zanziTestCreds')
   end
 
   it 'should use environment variables for credentials' do

--- a/spec/lib/zanzibar_spec.rb
+++ b/spec/lib/zanzibar_spec.rb
@@ -104,6 +104,17 @@ describe 'Zanzibar Test' do
     File.delete('attachment.txt')
   end
 
+  it 'should save a password to a file' do
+    stub_request(:any, 'https://www.zanzitest.net/webservices/sswebservice.asmx')
+      .to_return(body: AUTH_XML, status: 200).then
+      .to_return(body: SECRET_XML, status: 200)
+
+      client.get_password_and_save(1234, '.', 'zanziTestPassword')
+      expect(File.exist? 'zanziTestPassword')
+      expect(File.read('zanziTestPassword')).to eq(Base64.strict_encode64('zanziUserPassword'))
+      File.delete('zanziTestPassword')
+  end
+
   it 'should use environment variables for credentials' do
     ENV['ZANZIBAR_USER'] = 'environment_user'
     ENV['ZANZIBAR_PASSWORD'] = 'environment_password'

--- a/spec/lib/zanzibar_spec.rb
+++ b/spec/lib/zanzibar_spec.rb
@@ -111,7 +111,7 @@ describe 'Zanzibar Test' do
 
       client.get_password_and_save(1234, '.', 'zanziTestPassword')
       expect(File.exist? 'zanziTestPassword')
-      expect(File.read('zanziTestPassword')).to eq(Base64.strict_encode64('zanziUserPassword'))
+      expect(File.read('zanziTestPassword')).to eq('zanziUserPassword')
       File.delete('zanziTestPassword')
   end
 


### PR DESCRIPTION
When using a Zanzifile for password management it would be useful to be able to have those passwords saved to disk to prevent getting them every time. I Base64 encoded them, basically because it felt better than writing a plain text password to disk. I also cleaned up a couple of other things, such as a debug message that was throwing an error due to an undefined variable, and allowing the verbose flag to be used with the plunder command. 

@maclennann @cmoore-cimpress  
