### PR TITLE
Add a gitignore to secrets_dir

### DIFF
--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -48,8 +48,8 @@ module Zanzibar
         if @settings['secret_dir']
           FileUtils.mkdir_p(@settings['secret_dir'])
           File.open("#{@settings['secret_dir']}/.gitignore", 'w') do |file|
-            file.write '*'
-            file.write '!.gitignore'
+            file.puts '*'
+            file.puts '!.gitignore'
           end
         end
       end

--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -48,7 +48,7 @@ module Zanzibar
         if @settings['secret_dir']
           FileUtils.mkdir_p(@settings['secret_dir'])
           File.open("#{@settings['secret_dir']}/.gitignore", 'w') do |file|
-            file.write '.'
+            file.write '*'
             file.write '!.gitignore'
           end
         end

--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -49,6 +49,7 @@ module Zanzibar
           FileUtils.mkdir_p(@settings['secret_dir'])
           File.open("#{@settings['secret_dir']}/.gitignore", 'w') do |file|
             file.write '.'
+            file.write '!.gitignore'
           end
         end
       end

--- a/lib/zanzibar/actions/bundle.rb
+++ b/lib/zanzibar/actions/bundle.rb
@@ -44,7 +44,13 @@ module Zanzibar
       end
 
       def ensure_secrets_path
-        FileUtils.mkdir_p(@settings['secret_dir']) unless @settings['secret_dir'] == nil
+        ## Make sure the directory exists and that a .gitignore is there to ignore it
+        if @settings['secret_dir']
+          FileUtils.mkdir_p(@settings['secret_dir'])
+          File.open("#{@settings['secret_dir']}/.gitignore", 'w') do |file|
+            file.write '.'
+          end
+        end
       end
 
       def resolved_file?

--- a/spec/lib/zanzibar/actions/bundle_spec.rb
+++ b/spec/lib/zanzibar/actions/bundle_spec.rb
@@ -50,6 +50,12 @@ describe Zanzibar::Cli do
         expect(FakeFS::FileTest.file? File.join('secrets', 'zanzi_key')).to be(true)
       end
 
+      it 'should create a .gitignore' do
+        expect(FakeFS::FileTest.file? File.join('secrets', '.gitignore')).to be(false)
+        expect { subject.bundle }.to output(/Finished downloading secrets/).to_stdout
+        expect(FakeFS::FileTest.file? File.join('secrets', '.gitignore')).to be(true)
+      end
+
       it 'should create a resolved file' do
         expect(FakeFS::FileTest.file? Zanzibar::RESOLVED_NAME).to be(false)
         expect { subject.bundle }.to output(/Finished downloading secrets/).to_stdout


### PR DESCRIPTION
When someone specifies a secret_dir, we add a .gitignore file with that directory in it so that it doesn't sneak into git commits.

@maclennann @cleung2010 
