### PR TITLE
Update get.rb to remove 'puts'

### DIFF
--- a/lib/zanzibar/actions/get.rb
+++ b/lib/zanzibar/actions/get.rb
@@ -26,8 +26,6 @@ module Zanzibar
       def fetch_secret(scrt_id, label = nil)
         scrt = ::Zanzibar::Zanzibar.new(@zanzibar_options)
 
-        puts @zanzibar_options
-
         if label
           scrt.download_secret_file(scrt_id: scrt_id,
                                     type: label)


### PR DESCRIPTION
Remove the 'puts' dump of the options as it makes piping the output more difficult. Maybe better to add a verbosity flag and debug prints?
