### PR TITLE
Print response to indicate when cli is no longer interactive

### DIFF
--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -67,6 +67,7 @@ module Zanzibar
     def prompt_for_password
       puts "Please enter password for #{@@username}:"
       STDIN.noecho(&:gets).chomp
+      puts "Using password to login..."
     end
 
     ## Gets the wsdl document location if none is provided in the constructor


### PR DESCRIPTION
I love using the CLI, except for one pet peeve. A typical use case looks like this:

``` bash
$ zanzibar bundle
Checking for secrets declared in your Zanzifile...
Please enter password for <username>:
Finished downloading secrets!
```

I type in my password after the third line and press `ENTER`. During the precious precious hundreds of milliseconds before the final "Finished downloading secrets!" appears, there is zero indication that the CLI is actually doing work rather than getting stuck as CLIs sometimes do.

I'd added a line to indicate that user input was accepted and the CLI is no longer interactive. When I run the tests locally I get `28 examples, 0 failures`.
