### PR TITLE
Fix for prompt_for_password

### DIFF
--- a/lib/zanzibar.rb
+++ b/lib/zanzibar.rb
@@ -66,8 +66,9 @@ module Zanzibar
 
     def prompt_for_password
       puts "Please enter password for #{@@username}:"
-      STDIN.noecho(&:gets).chomp
-      puts "Using password to login..."
+      STDIN.noecho(&:gets).chomp.tap do
+        puts "Using password to login..."
+      end
     end
 
     ## Gets the wsdl document location if none is provided in the constructor


### PR DESCRIPTION
this is a fix for commit 813b171d2632f2b80b6bfa9b2b99bf3ebcf345a6 which broke the prompt_for_password method and resulted a nil password.
