### PR TITLE
Bumped savon gem version to fix depencency issue with rails 4.2+

### DIFF
--- a/zanzibar.gemspec
+++ b/zanzibar.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'fakefs', '~> 0.6.4'
   spec.add_development_dependency 'simplecov', '~> 0.9.1'
 
-  spec.add_runtime_dependency 'savon', '~> 2.8.0'
+  spec.add_runtime_dependency 'savon', '~> 2.10.0'
   spec.add_runtime_dependency 'rubyntlm', '~> 0.4.0'
   spec.add_runtime_dependency 'thor', '~> 0.19.0'
 end


### PR DESCRIPTION
Rails 4.2+ have a dependency on mime-types >= 2.6.2 and the current version of savon has a dependency of mime-type < 2.0.0 

I bumped the savon version to 2.10 which resolves this dependency.
