### PR TITLE
Improve error message when using invalid label

### DIFF
--- a/lib/zanzibar/client.rb
+++ b/lib/zanzibar/client.rb
@@ -86,6 +86,9 @@ module Zanzibar
       secret_items.each do |item|
         return item if item[:field_name] == field_name
       end
+      # key not found
+      availableFields = secret_items.map{|item| item[:field_name]}
+      raise KeyError, "Field '#{field_name}' not found; available fields are #{availableFields}."
     end
   end
 end


### PR DESCRIPTION
It's sometimes not obvious what to use for the `label` field in Zanzifile.  This error makes it clear what is available versus what the user requested.